### PR TITLE
Fix missing return value causing undefined behaviour

### DIFF
--- a/swarm_exploration/path_searching/src/kinodynamic_astar.cpp
+++ b/swarm_exploration/path_searching/src/kinodynamic_astar.cpp
@@ -647,7 +647,7 @@ Eigen::Vector3i KinodynamicAstar::posToIndex(Eigen::Vector3d pt) {
 }
 
 int KinodynamicAstar::timeToIndex(double time) {
-  int idx = floor((time - time_origin_) * inv_time_resolution_);
+  return floor((time - time_origin_) * inv_time_resolution_);
 }
 
 void KinodynamicAstar::stateTransit(Eigen::Matrix<double, 6, 1>& state0,


### PR DESCRIPTION
This missing return value can cause a failure in the kinodynamic search, leading to a segmentation fault.
This fix is from [this issue](https://github.com/HKUST-Aerial-Robotics/FUEL/issues/44) in the FUEL repository.