### PR TITLE
Suggested parametrization of map floor in map_publlisher node

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ We provide several sample environments, which can be selected in [swarm_explorat
 ```
 
 Other examples can be found in [map_generator/resource](uav_simulator/map_generator/resource). If you want to use your own environments, simply place the .pcd files in [map_generator/resource](uav_simulator/map_generator/resource), and follow the comments above to specify it. You may also need to change the bounding box of explored space in [exploration.launch](swarm_exploration/exploration_manager/launch/single_drone_planner.xml):
-
 ```xml
     <arg name="box_min_x" value="-10.0"/>
     <arg name="box_min_y" value="-15.0"/>
@@ -118,6 +117,13 @@ Other examples can be found in [map_generator/resource](uav_simulator/map_genera
     <arg name="box_max_x" value="10.0"/>
     <arg name="box_max_y" value="15.0"/>
     <arg name="box_max_z" value=" 2.0"/>
+```
+and the map_floor parameters in the map_publisher node [swarm_exxploration.launch](swarm_exploration/exploration_manager/launch/swarm_exporation.launch) to match the size of the map:
+```xml
+    <param name="map_floor/x_min" value="-7.5" type="double"/>
+    <param name="map_floor/x_max" value="7.5" type="double"/>
+    <param name="map_floor/y_min" value="-15.0" type="double"/>
+    <param name="map_floor/y_max" value="15.0" type="double"/>
 ```
 
 To create your own .pcd environments, you can use [this tool](https://github.com/HKUST-Aerial-Robotics/FUEL#creating-a-pcd-environment). 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Other examples can be found in [map_generator/resource](uav_simulator/map_genera
     <arg name="box_max_y" value="15.0"/>
     <arg name="box_max_z" value=" 2.0"/>
 ```
-and the map_floor parameters in the map_publisher node [swarm_exxploration.launch](swarm_exploration/exploration_manager/launch/swarm_exporation.launch) to match the size of the map:
+and the map_floor parameters in the map_publisher node in [swarm_exploration.launch](swarm_exploration/exploration_manager/launch/swarm_exploration.launch) or the exploration launch file that is going to be used to match the size of the map:
 ```xml
     <param name="map_floor/x_min" value="-7.5" type="double"/>
     <param name="map_floor/x_max" value="7.5" type="double"/>

--- a/swarm_exploration/exploration_manager/launch/swarm_exploration.launch
+++ b/swarm_exploration/exploration_manager/launch/swarm_exploration.launch
@@ -8,10 +8,12 @@
   <arg name="odom_prefix" value="/state_ukf/odom" />
   <arg name="drone_num" value="5" />
 
-    <!-- Map generation -->
-  <!-- <node pkg ="map_generator" name ="map_pub" type ="map_pub" output = "screen" args="$(find map_generator)/resource/office.pcd">    
-  </node> -->
-  <node pkg ="map_generator" name ="map_pub" type ="map_pub" output = "screen" args="$(find map_generator)/resource/pillar.pcd">    
+  <!-- Map generation -->
+  <node pkg ="map_generator" name ="map_pub" type ="map_pub" output = "screen" args="$(find map_generator)/resource/office.pcd">
+    <param name="map_floor/x_min" value="-7.5" type="double"/>
+    <param name="map_floor/x_max" value="7.5" type="double"/>
+    <param name="map_floor/y_min" value="-15.0" type="double"/>
+    <param name="map_floor/y_max" value="15.0" type="double"/>
   </node>
 
 <include file="$(find exploration_manager)/launch/single_drone_exploration.xml">

--- a/uav_simulator/map_generator/src/map_publisher.cpp
+++ b/uav_simulator/map_generator/src/map_publisher.cpp
@@ -7,6 +7,7 @@
 
 using namespace std;
 string file_name;
+double x_min, y_min, x_max, y_max;
 
 int main(int argc, char** argv)
 {
@@ -19,6 +20,11 @@ int main(int argc, char** argv)
   // file_name = "/home/boboyu/workspaces/catkin_ws/src/uav_simulator/map_generator/resource/tmp.pcd";
   // ros::Publisher cloud_pub = node.advertise<sensor_msgs::PointCloud2>("/pcl_render_node/local_map", 10, true);
 
+  node.param("map_pub/map_floor/x_min", x_min, -10.0);
+  node.param("map_pub/map_floor/x_max", x_max, 10.0);
+  node.param("map_pub/map_floor/y_min", y_min, -10.0);
+  node.param("map_pub/map_floor/y_max", y_max, 10.0);
+
   ros::Duration(1.0).sleep();
 
   /* load cloud from pcd */
@@ -30,25 +36,20 @@ int main(int argc, char** argv)
     return -1;
   }
 
-  // // Process map
-  // for (int i = 0; i < cloud.points.size(); ++i)
-  // {
-  //   auto pt = cloud.points[i];
-  //   pcl::PointXYZ pr;
-  //   pr.x = pt.x;
-  //   pr.y = -pt.z;
-  //   pr.z = pt.y;
-  //   cloud.points[i] = pr;
-  // }
-
-  for (double x = -7; x <= 7; x += 0.1)
-    for (double y = -15; y <= 15; y += 0.1)
+  /*
+  for (double x = -12; x <= 12; x += 0.1)
+    for (double y = -40; y <= 40; y += 0.1)
     {
       cloud.push_back(pcl::PointXYZ(x, y, 0));
     }
+  */
 
-  // cout << "Publishing map..." << endl;
-
+  for (double x = x_min; x <= x_max; x += 0.1)
+    for (double y = y_min; y <= y_max; y += 0.1)
+    {
+      cloud.push_back(pcl::PointXYZ(x, y, 0));
+    }
+  
   sensor_msgs::PointCloud2 msg;
   pcl::toROSMsg(cloud, msg);
   msg.header.frame_id = "world";


### PR DESCRIPTION
When I first started working with this repository, I created my own map using the provided map creator tool. My problem was that after creating my own map and following the instructions in the README file, the exploration did not go as expected because the map floor did not match the size of the actual map. The problem was that the map_publisher node was always creating the floor of the map with a size of 15x30, and mine was 40x40. I didn't realise this until I ran the exploration, as it is not specified in the README file in the Exploring Different Environments section. I suggest that these parameters should be more accessible and readable in the launch files, so I think this is a reasonable solution.